### PR TITLE
Initialize PayCodes app structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,39 @@
-# paycodesinit
+# PayCodes
+
+PayCodes is a lightweight toolkit for payment processing professionals. It combines MCC & chargeback code search, a fee breakdown calculator, and statement analysis in one app.
+
+## Project Structure
+
+- `client/` – React front end powered by Vite
+- `server/` – Node.js/Express API with MongoDB
+
+## Getting Started
+
+1. Install dependencies for both client and server.
+
+```bash
+cd server && npm install
+cd ../client && npm install
+```
+
+2. Create a `.env` file in `server/` based on `.env.example` and start the API:
+
+```bash
+npm run dev
+```
+
+3. In another terminal, start the React development server:
+
+```bash
+npm run dev
+```
+
+The client will be available at `http://localhost:3000` and the API at `http://localhost:5000`.
+
+## Core Features (planned)
+
+- MCC & Chargeback Code Wizard
+- Processing Fee Breakdown Calculator
+- Merchant Statement Analyzer
+
+

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>PayCodes</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "paycodes-client",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.2.0",
+    "vite": "^4.3.9"
+  }
+}

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,0 +1,8 @@
+export default function App() {
+  return (
+    <div>
+      <h1>PayCodes</h1>
+      <p>Welcome to PayCodes!</p>
+    </div>
+  );
+}

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 3000,
+  },
+});

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,2 @@
+PORT=5000
+MONGO_URI=mongodb://localhost:27017/paycodes

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,23 @@
+require('dotenv').config();
+const express = require('express');
+const cors = require('cors');
+const mongoose = require('mongoose');
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+const PORT = process.env.PORT || 5000;
+const MONGO_URI = process.env.MONGO_URI || 'mongodb://localhost:27017/paycodes';
+
+mongoose.connect(MONGO_URI)
+  .then(() => console.log('MongoDB connected'))
+  .catch(err => console.error('MongoDB connection error', err));
+
+app.get('/', (req, res) => {
+  res.json({ message: 'Welcome to PayCodes API' });
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "paycodes-server",
+  "version": "0.1.0",
+  "main": "index.js",
+  "license": "MIT",
+  "scripts": {
+    "start": "node index.js",
+    "dev": "nodemon index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "mongoose": "^7.6.0",
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.1"
+  },
+  "devDependencies": {
+    "nodemon": "^3.0.2"
+  }
+}


### PR DESCRIPTION
## Summary
- add server skeleton with Express and MongoDB connection
- add client skeleton using Vite React
- document project setup in README
- add .gitignore

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_686d6512ef8c832e8adf5c59d86f72d6