### PR TITLE
Add vercel config to avoid 404s

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/" }
+  ]
+}


### PR DESCRIPTION
## Summary
- provide `vercel.json` rewrite so React Router routes don't hit a 404

## Testing
- `npm run build` in `client`

------
https://chatgpt.com/codex/tasks/task_e_686d7aacd584832eb35bec15bff84e09