### PR TITLE
Revamp dashboard UI

### DIFF
--- a/client/src/components/Layout.jsx
+++ b/client/src/components/Layout.jsx
@@ -3,12 +3,10 @@ import Topbar from './Topbar';
 
 export default function Layout({ children }) {
   return (
-    <div className="flex min-h-screen">
+    <div className="min-h-screen bg-gray-50 font-sans">
       <Sidebar />
-      <div className="flex-1 flex flex-col overflow-hidden">
-        <Topbar />
-        <main className="flex-1 overflow-y-auto p-6">{children}</main>
-      </div>
+      <Topbar />
+      <main className="pt-12 pl-20 p-6">{children}</main>
     </div>
   );
 }

--- a/client/src/components/Sidebar.jsx
+++ b/client/src/components/Sidebar.jsx
@@ -1,28 +1,106 @@
 import { NavLink } from 'react-router-dom';
 
+function IconSearch() {
+  return (
+    <svg
+      className="w-6 h-6"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"
+      />
+    </svg>
+  );
+}
+
+function IconDocument() {
+  return (
+    <svg
+      className="w-6 h-6"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z"
+      />
+    </svg>
+  );
+}
+
+function IconCard() {
+  return (
+    <svg
+      className="w-6 h-6"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M2.25 8.25h19.5M2.25 9h19.5M4.5 14.25h6M4.5 16.5h3m-3.75 3h15a2.25 2.25 0 002.25-2.25V6.75A2.25 2.25 0 0019.5 4.5h-15A2.25 2.25 0 002.25 6.75v10.5A2.25 2.25 0 004.5 19.5z"
+      />
+    </svg>
+  );
+}
+
+function IconSettings() {
+  return (
+    <svg
+      className="w-6 h-6"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281a1.125 1.125 0 00.865.997l1.217.456a1.125 1.125 0 011.37-.49l1.296 2.247a1.125 1.125 0 01-.26 1.431l-1.003.827c-.293.24-.438.613-.431.992a6.758 6.758 0 010 .255c-.007.378.138.75.43.99l1.005.828c.424.35.534.954.26 1.43l-1.298 2.247a1.125 1.125 0 01-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.572 6.572 0 01-.22.128 1.125 1.125 0 00-.644.869l-.213 1.28c-.09.543-.56.941-1.11.941H10.7a1.125 1.125 0 01-1.11-.94l-.213-1.281a1.125 1.125 0 00-.645-.87l-.219-.127a1.125 1.125 0 00-1.076-.124l-1.217.456a1.125 1.125 0 01-1.37-.491L4.85 14.52a1.125 1.125 0 01.26-1.43l1.004-.827c.292-.24.437-.613.43-.992a6.934 6.934 0 010-.255c.007-.378-.138-.75-.43-.99l-1.004-.828a1.125 1.125 0 01-.26-1.43l1.297-2.247a1.125 1.125 0 011.37-.491l1.216.456c.356.133.751.072 1.076-.124.073-.044.147-.087.22-.128.332-.183.582-.495.644-.869l.214-1.281z"
+      />
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+      />
+    </svg>
+  );
+}
+
 const navItems = [
-  { to: '/', label: 'MCC Code Lookup' },
-  { to: '/processor-codes', label: 'Processor Response Codes' },
-  { to: '/chargeback-codes', label: 'Chargeback Codes' },
-  { to: '/statement-analysis', label: 'Statement Analysis' },
-  { to: '/fee-checker', label: 'Transaction Fee Checker' },
-  { to: '/settings', label: 'Settings' },
+  { to: '/', label: 'MCC', icon: IconSearch },
+  { to: '/processor-codes', label: 'Processor', icon: IconDocument },
+  { to: '/chargeback-codes', label: 'Chargebacks', icon: IconCard },
+  { to: '/statement-analysis', label: 'Statements', icon: IconDocument },
+  { to: '/fee-checker', label: 'Fees', icon: IconCard },
+  { to: '/settings', label: 'Settings', icon: IconSettings },
 ];
 
 export default function Sidebar() {
   return (
-    <aside className="bg-white border-r border-gray-200 text-gray-800 p-6 w-64 space-y-4">
-      <h2 className="text-xl font-bold mb-4">PayCodes</h2>
-      <nav className="space-y-1">
+    <aside className="fixed top-0 left-0 h-screen w-20 bg-white border-r shadow-sm flex flex-col items-center py-4 space-y-6 z-20">
+      <h2 className="text-lg font-bold">PC</h2>
+      <nav className="flex flex-col space-y-6 mt-4">
         {navItems.map((item) => (
           <NavLink
             key={item.to}
             to={item.to}
             className={({ isActive }) =>
-              `block rounded-lg px-3 py-2 hover:bg-gray-100 ${isActive ? 'text-lightspeed font-medium' : 'text-gray-600'}`
+              `flex flex-col items-center text-xs ${isActive ? 'text-indigo-600 font-medium' : 'text-gray-500'}`
             }
           >
-            {item.label}
+            <item.icon />
+            <span className="mt-1">{item.label}</span>
           </NavLink>
         ))}
       </nav>

--- a/client/src/components/Topbar.jsx
+++ b/client/src/components/Topbar.jsx
@@ -1,17 +1,10 @@
 export default function Topbar() {
   return (
-    <header className="bg-white border-b border-gray-200 p-4 flex justify-between items-center">
-      <div className="flex-1 max-w-sm">
-        <input
-          type="text"
-          placeholder="Search"
-          className="border rounded-lg p-2 w-full bg-gray-50 focus:outline-none focus:ring-2 focus:ring-lightspeed"
-        />
-      </div>
-      <div className="space-x-4 flex items-center">
-        <button className="text-gray-500">Alerts</button>
-        <div className="w-8 h-8 bg-gray-200 rounded-full" />
-      </div>
+    <header className="fixed top-0 left-20 right-0 h-12 bg-white border-b shadow-sm flex items-center justify-end px-6 z-10">
+      <button className="text-gray-500 mr-4" aria-label="Notifications">
+        🔔
+      </button>
+      <div className="w-8 h-8 bg-gray-200 rounded-full" />
     </header>
   );
 }

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -5,7 +5,8 @@
 @layer base {
   body {
     font-family: theme('fontFamily.sans');
-    background-color: #f5f5f7;
+    background-color: #f8f9fb;
     color: #333;
+    line-height: 1.5;
   }
 }

--- a/client/src/pages/ChargebackCodes.jsx
+++ b/client/src/pages/ChargebackCodes.jsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 export default function ChargebackCodes() {
   const [query, setQuery] = useState('');
   return (
-    <div className="bg-white p-4 rounded-2xl shadow-md">
+    <div className="bg-white p-6 rounded-lg shadow-sm border">
       <input
         type="text"
         placeholder="Search code"

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -3,15 +3,15 @@ export default function Dashboard() {
     <div className="space-y-6">
       <h1 className="text-2xl font-medium text-gray-900">Dashboard</h1>
       <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-        <div className="bg-white rounded-2xl shadow-sm p-6">
+        <div className="bg-white rounded-lg shadow-sm border p-6">
           <p className="text-sm text-gray-500">Current Balance</p>
           <p className="mt-2 text-2xl font-semibold">$12,480</p>
         </div>
-        <div className="bg-white rounded-2xl shadow-sm p-6">
+        <div className="bg-white rounded-lg shadow-sm border p-6">
           <p className="text-sm text-gray-500">Payments this month</p>
           <p className="mt-2 text-2xl font-semibold">$98,000</p>
         </div>
-        <div className="bg-white rounded-2xl shadow-sm p-6">
+        <div className="bg-white rounded-lg shadow-sm border p-6">
           <p className="text-sm text-gray-500">New Customers</p>
           <p className="mt-2 text-2xl font-semibold">24</p>
         </div>

--- a/client/src/pages/FeeCalculator.jsx
+++ b/client/src/pages/FeeCalculator.jsx
@@ -16,7 +16,7 @@ export default function FeeCalculator() {
 
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-      <form onSubmit={calculate} className="bg-white p-4 rounded-2xl shadow-md space-y-4">
+      <form onSubmit={calculate} className="bg-white p-6 rounded-lg shadow-sm border space-y-4">
         <div>
           <label className="block mb-1">Monthly Volume</label>
           <input
@@ -35,11 +35,11 @@ export default function FeeCalculator() {
             className="border rounded-xl p-2 w-full"
           />
         </div>
-        <button type="submit" className="bg-indigo-600 text-white rounded-xl p-3">
+        <button type="submit" className="bg-indigo-600 text-white rounded-md px-4 py-2">
           Calculate
         </button>
       </form>
-      <div className="bg-white p-4 rounded-2xl shadow-md flex flex-col justify-center items-center">
+      <div className="bg-white p-6 rounded-lg shadow-sm border flex flex-col justify-center items-center">
         {rate !== null ? (
           <>
             <div className="text-lg">

--- a/client/src/pages/MccLookup.jsx
+++ b/client/src/pages/MccLookup.jsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 export default function MccLookup() {
   const [query, setQuery] = useState('');
   return (
-    <div className="bg-white p-4 rounded-2xl shadow-md">
+    <div className="bg-white p-6 rounded-lg shadow-sm border">
       <input
         type="text"
         placeholder="Search MCC"

--- a/client/src/pages/ProcessorCodes.jsx
+++ b/client/src/pages/ProcessorCodes.jsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 export default function ProcessorCodes() {
   const [query, setQuery] = useState('');
   return (
-    <div className="bg-white p-4 rounded-2xl shadow-md">
+    <div className="bg-white p-6 rounded-lg shadow-sm border">
       <input
         type="text"
         placeholder="Search processor response"

--- a/client/src/pages/Settings.jsx
+++ b/client/src/pages/Settings.jsx
@@ -1,6 +1,6 @@
 export default function Settings() {
   return (
-    <div className="bg-white p-4 rounded-2xl shadow-md">
+    <div className="bg-white p-6 rounded-lg shadow-sm border">
       <h2 className="text-lg font-medium mb-2">Settings</h2>
       <p className="text-sm text-gray-500">User preferences will appear here.</p>
     </div>

--- a/client/src/pages/StatementUpload.jsx
+++ b/client/src/pages/StatementUpload.jsx
@@ -16,14 +16,14 @@ export default function StatementUpload() {
   return (
     <div className="space-y-6">
       <div
-        className="border-2 border-dashed rounded-2xl p-10 text-center bg-white"
+        className="border-2 border-dashed rounded-lg p-10 text-center bg-white"
         onDragOver={(e) => e.preventDefault()}
         onDrop={handleDrop}
       >
         {loading ? 'Extracting data…' : 'Drag & drop statement PDF'}
       </div>
       {results && (
-        <div className="bg-white p-4 rounded-2xl shadow-md">
+        <div className="bg-white p-6 rounded-lg shadow-sm border">
           <div className="flex justify-between">
             <h3 className="font-medium">Parsed Results</h3>
             <div>


### PR DESCRIPTION
## Summary
- restyle layout with fixed sidebar and header bar
- simplify navigation with icons
- update content card styling across pages
- apply light gray background and clean typography

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d84293c24832e9fd138a543305510