### PR TITLE
Add MCC search functionality

### DIFF
--- a/client/src/pages/MccLookup.jsx
+++ b/client/src/pages/MccLookup.jsx
@@ -1,19 +1,47 @@
 import { useState } from 'react';
 
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:5000';
+
 export default function MccLookup() {
   const [query, setQuery] = useState('');
+  const [results, setResults] = useState([]);
+
+  const handleSearch = async (e) => {
+    if (e) e.preventDefault();
+    if (!query.trim()) return;
+    try {
+      const res = await fetch(`${API_URL}/api/mcc?q=${encodeURIComponent(query)}`);
+      const data = await res.json();
+      setResults(data);
+    } catch (err) {
+      console.error('Search failed', err);
+    }
+  };
+
   return (
     <div className="bg-white p-6 rounded-lg shadow-sm border">
-      <input
-        type="text"
-        placeholder="Search MCC"
-        value={query}
-        onChange={(e) => setQuery(e.target.value)}
-        className="border rounded-xl p-2 w-full"
-      />
-      <div className="mt-4">
-        <p className="font-medium">MCC 5999</p>
-        <p className="text-sm">Miscellaneous retail stores</p>
+      <form onSubmit={handleSearch} className="flex space-x-2">
+        <input
+          type="text"
+          placeholder="Search MCC"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          className="border rounded-xl p-2 w-full"
+        />
+        <button
+          type="submit"
+          className="bg-blue-500 text-white rounded-xl px-4"
+        >
+          Search
+        </button>
+      </form>
+      <div className="mt-4 space-y-2">
+        {results.map((item) => (
+          <div key={item._id} className="border rounded p-2">
+            <p className="font-medium">MCC {item.mcc_code}</p>
+            <p className="text-sm">{item.category}</p>
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/server/index.js
+++ b/server/index.js
@@ -3,13 +3,14 @@ const express = require('express');
 const cors = require('cors');
 const { MongoClient, ServerApiVersion } = require('mongodb');
 const mongoose = require('mongoose');
+const Mcc = require('./models/Mcc');
 
 const app = express();
 app.use(cors());
 app.use(express.json());
 
 const PORT = process.env.PORT || 5000;
-const MONGO_URI = process.env.MONGO_URI || 'mongodb://localhost:27017/paycodes';
+const MONGO_URI = process.env.MONGO_URI || 'mongodb://localhost:27017/paycodesdb';
 
 const client = new MongoClient(MONGO_URI, {
   serverApi: {
@@ -36,6 +37,23 @@ mongoose.connect(MONGO_URI)
 
 app.get('/', (req, res) => {
   res.json({ message: 'Welcome to PayCodes API' });
+});
+
+app.get('/api/mcc', async (req, res) => {
+  const { q } = req.query;
+  if (!q) {
+    return res.json([]);
+  }
+  try {
+    const regex = new RegExp(q, 'i');
+    const results = await Mcc.find({
+      $or: [{ mcc_code: q }, { category: regex }]
+    }).limit(20);
+    res.json(results);
+  } catch (err) {
+    console.error('Search error', err);
+    res.status(500).json({ error: 'Server error' });
+  }
 });
 
 app.listen(PORT, () => {

--- a/server/models/Mcc.js
+++ b/server/models/Mcc.js
@@ -1,0 +1,8 @@
+const mongoose = require('mongoose');
+
+const MccSchema = new mongoose.Schema({
+  mcc_code: String,
+  category: String
+});
+
+module.exports = mongoose.model('Mcc', MccSchema, 'mcc');


### PR DESCRIPTION
## Summary
- add mongoose model for MCC codes
- update server to expose `/api/mcc` search endpoint
- adjust default MongoDB name to `paycodesdb`
- build MCC Lookup page with live search

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d983852a0832ea8ce2c60af31f2ae