### PR TITLE
Fix MCC search filtering

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -29,13 +29,14 @@ app.get('/api/mcc', async (req, res) => {
     const regex = new RegExp(q, 'i');
     const filter = {
       $or: [
+        // Match MCC codes that start with the query
         { mcc_code: { $regex: `^${q}` } },
+        // Or categories that contain the query, case-insensitive
         { category: regex }
       ]
     };
-    const results = await Mcc.find({
-      $or: [{ mcc_code: q }, { category: regex }]
-    }).limit(20);
+
+    const results = await Mcc.find(filter).limit(20);
     res.json(results);
   } catch (err) {
     console.error('Search error', err);


### PR DESCRIPTION
## Summary
- use the generated filter when querying MCC search results so partial code and category matches return data

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686da0677094832e8ba4070429e7035d