### PR TITLE
Improve dashboard styling

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -6,6 +6,7 @@ import ChargebackCodes from './pages/ChargebackCodes';
 import StatementUpload from './pages/StatementUpload';
 import FeeCalculator from './pages/FeeCalculator';
 import Settings from './pages/Settings';
+import Reports from './pages/Reports';
 
 export default function App() {
   return (
@@ -17,6 +18,7 @@ export default function App() {
           <Route path="/chargeback-codes" element={<ChargebackCodes />} />
           <Route path="/statement-analysis" element={<StatementUpload />} />
           <Route path="/fee-checker" element={<FeeCalculator />} />
+          <Route path="/reports" element={<Reports />} />
           <Route path="/settings" element={<Settings />} />
         </Routes>
       </Layout>

--- a/client/src/components/Card.jsx
+++ b/client/src/components/Card.jsx
@@ -1,0 +1,7 @@
+export default function Card({ as: Tag = 'div', children, className = '', ...props }) {
+  return (
+    <Tag className={`bg-white rounded-xl shadow border border-gray-200 p-6 ${className}`} {...props}>
+      {children}
+    </Tag>
+  );
+}

--- a/client/src/components/Layout.jsx
+++ b/client/src/components/Layout.jsx
@@ -3,10 +3,10 @@ import Topbar from './Topbar';
 
 export default function Layout({ children }) {
   return (
-    <div className="min-h-screen bg-gray-50 font-sans">
+    <div className="min-h-screen bg-gray-100 font-sans text-gray-800">
       <Sidebar />
       <Topbar />
-      <main className="pt-12 pl-20 p-6">{children}</main>
+      <main className="max-w-7xl mx-auto pt-16 pl-14 pr-6 pb-8 space-y-8">{children}</main>
     </div>
   );
 }

--- a/client/src/components/Sidebar.jsx
+++ b/client/src/components/Sidebar.jsx
@@ -82,21 +82,22 @@ const navItems = [
   { to: '/processor-codes', label: 'Processor', icon: IconDocument },
   { to: '/chargeback-codes', label: 'Chargebacks', icon: IconCard },
   { to: '/statement-analysis', label: 'Statements', icon: IconDocument },
+  { to: '/reports', label: 'Reports', icon: IconDocument },
   { to: '/fee-checker', label: 'Fees', icon: IconCard },
   { to: '/settings', label: 'Settings', icon: IconSettings },
 ];
 
 export default function Sidebar() {
   return (
-    <aside className="fixed top-0 left-0 h-screen w-20 bg-white border-r shadow-sm flex flex-col items-center py-4 space-y-6 z-20">
-      <h2 className="text-lg font-bold">PC</h2>
+    <aside className="fixed top-0 left-0 h-screen w-14 bg-white border-r border-gray-200 shadow-sm flex flex-col items-center py-4 space-y-8 z-20">
+      <h2 className="text-lg font-semibold">PC</h2>
       <nav className="flex flex-col space-y-6 mt-4">
         {navItems.map((item) => (
           <NavLink
             key={item.to}
             to={item.to}
             className={({ isActive }) =>
-              `flex flex-col items-center text-xs ${isActive ? 'text-indigo-600 font-medium' : 'text-gray-500'}`
+              `flex flex-col items-center text-xs px-2 py-2 rounded-md ${isActive ? 'text-indigo-600 font-medium bg-gray-100' : 'text-gray-500 hover:text-indigo-600 hover:bg-gray-50'}`
             }
           >
             <item.icon />

--- a/client/src/components/Topbar.jsx
+++ b/client/src/components/Topbar.jsx
@@ -1,10 +1,13 @@
 export default function Topbar() {
   return (
-    <header className="fixed top-0 left-20 right-0 h-12 bg-white border-b shadow-sm flex items-center justify-end px-6 z-10">
-      <button className="text-gray-500 mr-4" aria-label="Notifications">
+    <header className="fixed top-0 left-14 right-0 h-14 bg-white/80 backdrop-blur border-b border-gray-200 shadow-sm flex items-center justify-end px-6 space-x-4 z-10">
+      <button className="text-gray-500 hover:text-gray-700" aria-label="Notifications">
         🔔
       </button>
-      <div className="w-8 h-8 bg-gray-200 rounded-full" />
+      <div className="flex items-center space-x-2">
+        <div className="w-8 h-8 bg-gray-200 rounded-full" />
+        <span className="text-sm font-medium text-gray-700">Admin</span>
+      </div>
     </header>
   );
 }

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -5,8 +5,9 @@
 @layer base {
   body {
     font-family: theme('fontFamily.sans');
-    background-color: #f8f9fb;
-    color: #333;
+    background-color: #f9fafb;
+    color: #374151;
     line-height: 1.5;
+    -webkit-font-smoothing: antialiased;
   }
 }

--- a/client/src/pages/ChargebackCodes.jsx
+++ b/client/src/pages/ChargebackCodes.jsx
@@ -1,20 +1,21 @@
 import { useState } from 'react';
+import Card from '../components/Card';
 
 export default function ChargebackCodes() {
   const [query, setQuery] = useState('');
   return (
-    <div className="bg-white p-6 rounded-lg shadow-sm border">
+    <Card>
       <input
         type="text"
         placeholder="Search code"
         value={query}
         onChange={(e) => setQuery(e.target.value)}
-        className="border rounded-xl p-2 w-full"
+        className="border border-gray-300 rounded-md p-2 w-full"
       />
       <div className="mt-4">
         <p className="font-medium">Code 4837 - Visa</p>
         <p className="text-sm">No cardholder authorization</p>
       </div>
-    </div>
+    </Card>
   );
 }

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -1,20 +1,22 @@
+import Card from '../components/Card';
+
 export default function Dashboard() {
   return (
     <div className="space-y-6">
       <h1 className="text-2xl font-medium text-gray-900">Dashboard</h1>
       <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-        <div className="bg-white rounded-lg shadow-sm border p-6">
+        <Card>
           <p className="text-sm text-gray-500">Current Balance</p>
           <p className="mt-2 text-2xl font-semibold">$12,480</p>
-        </div>
-        <div className="bg-white rounded-lg shadow-sm border p-6">
+        </Card>
+        <Card>
           <p className="text-sm text-gray-500">Payments this month</p>
           <p className="mt-2 text-2xl font-semibold">$98,000</p>
-        </div>
-        <div className="bg-white rounded-lg shadow-sm border p-6">
+        </Card>
+        <Card>
           <p className="text-sm text-gray-500">New Customers</p>
           <p className="mt-2 text-2xl font-semibold">24</p>
-        </div>
+        </Card>
       </div>
     </div>
   );

--- a/client/src/pages/FeeCalculator.jsx
+++ b/client/src/pages/FeeCalculator.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import Card from '../components/Card';
 
 export default function FeeCalculator() {
   const [volume, setVolume] = useState('');
@@ -16,14 +17,14 @@ export default function FeeCalculator() {
 
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-      <form onSubmit={calculate} className="bg-white p-6 rounded-lg shadow-sm border space-y-4">
+      <Card as="form" onSubmit={calculate} className="space-y-4">
         <div>
           <label className="block mb-1">Monthly Volume</label>
           <input
             type="number"
             value={volume}
             onChange={(e) => setVolume(e.target.value)}
-            className="border rounded-xl p-2 w-full"
+            className="border border-gray-300 rounded-md p-2 w-full"
           />
         </div>
         <div>
@@ -32,14 +33,14 @@ export default function FeeCalculator() {
             type="number"
             value={ticket}
             onChange={(e) => setTicket(e.target.value)}
-            className="border rounded-xl p-2 w-full"
+            className="border border-gray-300 rounded-md p-2 w-full"
           />
         </div>
-        <button type="submit" className="bg-indigo-600 text-white rounded-md px-4 py-2">
+        <button type="submit" className="bg-indigo-600 hover:bg-indigo-700 text-white rounded-md px-4 py-2">
           Calculate
         </button>
-      </form>
-      <div className="bg-white p-6 rounded-lg shadow-sm border flex flex-col justify-center items-center">
+      </Card>
+      <Card className="flex flex-col justify-center items-center">
         {rate !== null ? (
           <>
             <div className="text-lg">
@@ -51,7 +52,7 @@ export default function FeeCalculator() {
         ) : (
           <p className="text-gray-500">Enter details to calculate fees</p>
         )}
-      </div>
+      </Card>
     </div>
   );
 }

--- a/client/src/pages/MccLookup.jsx
+++ b/client/src/pages/MccLookup.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import Card from '../components/Card';
 
 const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:5000';
 
@@ -52,18 +53,18 @@ export default function MccLookup() {
   };
 
   return (
-    <div className="bg-white p-6 rounded-lg shadow-sm border">
+    <Card>
       <form onSubmit={handleSearch} className="flex space-x-2">
         <input
           type="text"
           placeholder="Search MCC"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
-          className="border rounded-xl p-2 w-full"
+          className="border border-gray-300 rounded-md p-2 w-full"
         />
         <button
           type="submit"
-          className="bg-blue-500 text-white rounded-xl px-4"
+          className="bg-indigo-600 hover:bg-indigo-700 text-white rounded-md px-4"
         >
           Search
         </button>
@@ -71,7 +72,7 @@ export default function MccLookup() {
 
       <div className="mt-4 space-y-2">
         {results.map((item) => (
-          <div key={item._id} className="border rounded p-2">
+          <div key={item._id} className="border border-gray-200 rounded-md p-2">
             <p className="font-medium">MCC {item.mcc_code}</p>
             <p className="text-sm">{item.category}</p>
           </div>
@@ -81,6 +82,6 @@ export default function MccLookup() {
           <p className="text-sm text-gray-500">No results found.</p>
         )}
       </div>
-    </div>
+    </Card>
   );
 }

--- a/client/src/pages/ProcessorCodes.jsx
+++ b/client/src/pages/ProcessorCodes.jsx
@@ -1,20 +1,21 @@
 import { useState } from 'react';
+import Card from '../components/Card';
 
 export default function ProcessorCodes() {
   const [query, setQuery] = useState('');
   return (
-    <div className="bg-white p-6 rounded-lg shadow-sm border">
+    <Card>
       <input
         type="text"
         placeholder="Search processor response"
         value={query}
         onChange={(e) => setQuery(e.target.value)}
-        className="border rounded-xl p-2 w-full"
+        className="border border-gray-300 rounded-md p-2 w-full"
       />
       <div className="mt-4">
         <p className="font-medium">Response 05</p>
         <p className="text-sm">Do Not Honor</p>
       </div>
-    </div>
+    </Card>
   );
 }

--- a/client/src/pages/Reports.jsx
+++ b/client/src/pages/Reports.jsx
@@ -1,3 +1,9 @@
+import Card from '../components/Card';
+
 export default function Reports() {
-  return <div className="p-4">Your saved reports will appear here.</div>;
+  return (
+    <Card>
+      <p className="text-gray-500">Your saved reports will appear here.</p>
+    </Card>
+  );
 }

--- a/client/src/pages/Settings.jsx
+++ b/client/src/pages/Settings.jsx
@@ -1,8 +1,10 @@
+import Card from '../components/Card';
+
 export default function Settings() {
   return (
-    <div className="bg-white p-6 rounded-lg shadow-sm border">
+    <Card>
       <h2 className="text-lg font-medium mb-2">Settings</h2>
       <p className="text-sm text-gray-500">User preferences will appear here.</p>
-    </div>
+    </Card>
   );
 }

--- a/client/src/pages/StatementUpload.jsx
+++ b/client/src/pages/StatementUpload.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import Card from '../components/Card';
 
 export default function StatementUpload() {
   const [loading, setLoading] = useState(false);
@@ -16,14 +17,14 @@ export default function StatementUpload() {
   return (
     <div className="space-y-6">
       <div
-        className="border-2 border-dashed rounded-lg p-10 text-center bg-white"
+        className="border-2 border-dashed border-gray-300 rounded-lg p-10 text-center bg-white"
         onDragOver={(e) => e.preventDefault()}
         onDrop={handleDrop}
       >
         {loading ? 'Extracting data…' : 'Drag & drop statement PDF'}
       </div>
       {results && (
-        <div className="bg-white p-6 rounded-lg shadow-sm border">
+        <Card>
           <div className="flex justify-between">
             <h3 className="font-medium">Parsed Results</h3>
             <div>
@@ -34,7 +35,7 @@ export default function StatementUpload() {
           <ul className="mt-2 text-sm text-red-600 list-disc list-inside">
             <li>Junk fee detected: $10</li>
           </ul>
-        </div>
+        </Card>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- refine layout with lighter background and narrower sidebar
- adjust topbar alignment
- add reports page to navigation

The earlier attempt didn't visibly change much because the sidebar width and base colors stayed the same, so the layout still looked identical. This update tweaks the spacing, colors, and routes to make the new theme more apparent.

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686da5a33704832e9d722e71533be28d