### PR TITLE
Revamp frontend with ChatGPT style

### DIFF
--- a/client/src/components/Layout.jsx
+++ b/client/src/components/Layout.jsx
@@ -3,10 +3,10 @@ import Topbar from './Topbar';
 
 export default function Layout({ children }) {
   return (
-    <div className="min-h-screen bg-gray-50 font-sans text-gray-800">
+    <div className="min-h-screen bg-[#343541] font-sans text-gray-100">
       <Sidebar />
       <Topbar />
-      <main className="pt-24 pl-64 p-8 max-w-5xl mx-auto space-y-6">{children}</main>
+      <main className="pt-20 pl-60 p-6 max-w-3xl mx-auto space-y-6">{children}</main>
     </div>
   );
 }

--- a/client/src/components/Sidebar.jsx
+++ b/client/src/components/Sidebar.jsx
@@ -1,106 +1,28 @@
 import { NavLink } from 'react-router-dom';
 
-function IconSearch() {
-  return (
-    <svg
-      className="w-6 h-6"
-      fill="none"
-      viewBox="0 0 24 24"
-      strokeWidth={1.5}
-      stroke="currentColor"
-    >
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"
-      />
-    </svg>
-  );
-}
-
-function IconDocument() {
-  return (
-    <svg
-      className="w-6 h-6"
-      fill="none"
-      viewBox="0 0 24 24"
-      strokeWidth={1.5}
-      stroke="currentColor"
-    >
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z"
-      />
-    </svg>
-  );
-}
-
-function IconCard() {
-  return (
-    <svg
-      className="w-6 h-6"
-      fill="none"
-      viewBox="0 0 24 24"
-      strokeWidth={1.5}
-      stroke="currentColor"
-    >
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        d="M2.25 8.25h19.5M2.25 9h19.5M4.5 14.25h6M4.5 16.5h3m-3.75 3h15a2.25 2.25 0 002.25-2.25V6.75A2.25 2.25 0 0019.5 4.5h-15A2.25 2.25 0 002.25 6.75v10.5A2.25 2.25 0 004.5 19.5z"
-      />
-    </svg>
-  );
-}
-
-function IconSettings() {
-  return (
-    <svg
-      className="w-6 h-6"
-      fill="none"
-      viewBox="0 0 24 24"
-      strokeWidth={1.5}
-      stroke="currentColor"
-    >
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281a1.125 1.125 0 00.865.997l1.217.456a1.125 1.125 0 011.37-.49l1.296 2.247a1.125 1.125 0 01-.26 1.431l-1.003.827c-.293.24-.438.613-.431.992a6.758 6.758 0 010 .255c-.007.378.138.75.43.99l1.005.828c.424.35.534.954.26 1.43l-1.298 2.247a1.125 1.125 0 01-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.572 6.572 0 01-.22.128 1.125 1.125 0 00-.644.869l-.213 1.28c-.09.543-.56.941-1.11.941H10.7a1.125 1.125 0 01-1.11-.94l-.213-1.281a1.125 1.125 0 00-.645-.87l-.219-.127a1.125 1.125 0 00-1.076-.124l-1.217.456a1.125 1.125 0 01-1.37-.491L4.85 14.52a1.125 1.125 0 01.26-1.43l1.004-.827c.292-.24.437-.613.43-.992a6.934 6.934 0 010-.255c.007-.378-.138-.75-.43-.99l-1.004-.828a1.125 1.125 0 01-.26-1.43l1.297-2.247a1.125 1.125 0 011.37-.491l1.216.456c.356.133.751.072 1.076-.124.073-.044.147-.087.22-.128.332-.183.582-.495.644-.869l.214-1.281z"
-      />
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-      />
-    </svg>
-  );
-}
-
 const navItems = [
-  { to: '/', label: 'MCC', icon: IconSearch },
-  { to: '/processor-codes', label: 'Processor', icon: IconDocument },
-  { to: '/chargeback-codes', label: 'Chargebacks', icon: IconCard },
-  { to: '/statement-analysis', label: 'Statements', icon: IconDocument },
-  { to: '/fee-checker', label: 'Fees', icon: IconCard },
-  { to: '/settings', label: 'Settings', icon: IconSettings },
+  { to: '/', label: 'MCC' },
+  { to: '/processor-codes', label: 'Processor' },
+  { to: '/chargeback-codes', label: 'Chargebacks' },
+  { to: '/statement-analysis', label: 'Statements' },
+  { to: '/fee-checker', label: 'Fees' },
+  { to: '/settings', label: 'Settings' },
 ];
 
 export default function Sidebar() {
   return (
-    <aside className="fixed top-0 left-0 h-screen w-64 bg-white border-r border-gray-200 shadow-sm flex flex-col p-6 space-y-8 z-20">
-      <h2 className="text-2xl font-bold text-indigo-600">PayCodes</h2>
-      <nav className="flex-1 flex flex-col space-y-2 mt-4">
+    <aside className="fixed top-0 left-0 h-screen w-60 bg-[#202123] border-r border-[#343541] shadow-md flex flex-col p-4 space-y-8 z-20">
+      <h2 className="text-xl font-semibold text-gray-100">PayCodes</h2>
+      <nav className="flex-1 flex flex-col space-y-1 mt-4">
         {navItems.map((item) => (
           <NavLink
             key={item.to}
             to={item.to}
             className={({ isActive }) =>
-              `flex items-center space-x-3 rounded-md px-3 py-2 text-sm hover:bg-gray-100 ${isActive ? 'bg-gray-100 text-indigo-600' : 'text-gray-600'}`
+              `rounded px-3 py-2 text-sm hover:bg-[#343541] ${isActive ? 'bg-[#343541] text-white' : 'text-gray-300'}`
             }
           >
-            <item.icon />
-            <span>{item.label}</span>
+            {item.label}
           </NavLink>
         ))}
       </nav>

--- a/client/src/components/Topbar.jsx
+++ b/client/src/components/Topbar.jsx
@@ -1,13 +1,7 @@
 export default function Topbar() {
   return (
-    <header className="fixed top-0 left-64 right-0 h-14 bg-white/90 backdrop-blur border-b border-gray-200 shadow-sm flex items-center justify-end px-8 space-x-4 z-10">
-      <button className="text-gray-500 hover:text-gray-700" aria-label="Notifications">
-        🔔
-      </button>
-      <div className="flex items-center space-x-2">
-        <div className="w-8 h-8 bg-gray-200 rounded-full" />
-        <span className="text-sm font-medium text-gray-700">Admin</span>
-      </div>
+    <header className="fixed top-0 left-60 right-0 h-14 bg-[#343541] border-b border-[#40414f] flex items-center px-4 text-gray-100 z-10">
+      <h1 className="text-base font-medium">PayCodes</h1>
     </header>
   );
 }

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -4,7 +4,7 @@
 
 @layer base {
   body {
-    @apply bg-gray-50 text-gray-800 font-sans antialiased;
+    @apply bg-[#343541] text-gray-100 font-sans antialiased;
     line-height: 1.5;
   }
 }

--- a/client/src/pages/ChargebackCodes.jsx
+++ b/client/src/pages/ChargebackCodes.jsx
@@ -3,13 +3,13 @@ import { useState } from 'react';
 export default function ChargebackCodes() {
   const [query, setQuery] = useState('');
   return (
-    <div className="bg-white p-8 rounded-lg shadow-sm border border-gray-200 space-y-4">
+    <div className="bg-[#444654] p-8 rounded-lg shadow-sm border border-[#343541] space-y-4 text-gray-100">
       <input
         type="text"
         placeholder="Search code"
         value={query}
         onChange={(e) => setQuery(e.target.value)}
-        className="border border-gray-300 rounded-md p-3 w-full"
+        className="border border-gray-500 rounded-md p-3 w-full bg-transparent"
       />
       <div>
         <p className="font-medium">Code 4837 - Visa</p>

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -1,17 +1,17 @@
 export default function Dashboard() {
   return (
-    <div className="space-y-6">
-      <h1 className="text-2xl font-medium text-gray-900">Dashboard</h1>
+    <div className="space-y-6 text-gray-100">
+      <h1 className="text-2xl font-medium">Dashboard</h1>
       <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-8">
+        <div className="bg-[#444654] rounded-lg shadow-sm border border-[#343541] p-8">
           <p className="text-sm text-gray-500">Current Balance</p>
           <p className="mt-2 text-2xl font-semibold">$12,480</p>
         </div>
-        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-8">
+        <div className="bg-[#444654] rounded-lg shadow-sm border border-[#343541] p-8">
           <p className="text-sm text-gray-500">Payments this month</p>
           <p className="mt-2 text-2xl font-semibold">$98,000</p>
         </div>
-        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-8">
+        <div className="bg-[#444654] rounded-lg shadow-sm border border-[#343541] p-8">
           <p className="text-sm text-gray-500">New Customers</p>
           <p className="mt-2 text-2xl font-semibold">24</p>
         </div>

--- a/client/src/pages/FeeCalculator.jsx
+++ b/client/src/pages/FeeCalculator.jsx
@@ -16,14 +16,14 @@ export default function FeeCalculator() {
 
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-      <form onSubmit={calculate} className="bg-white p-8 rounded-lg shadow-sm border border-gray-200 space-y-4">
+      <form onSubmit={calculate} className="bg-[#444654] p-8 rounded-lg shadow-sm border border-[#343541] space-y-4 text-gray-100">
         <div>
           <label className="block mb-1">Monthly Volume</label>
           <input
             type="number"
             value={volume}
             onChange={(e) => setVolume(e.target.value)}
-            className="border border-gray-300 rounded-md p-3 w-full"
+            className="border border-gray-500 rounded-md p-3 w-full bg-transparent"
           />
         </div>
         <div>
@@ -32,7 +32,7 @@ export default function FeeCalculator() {
             type="number"
             value={ticket}
             onChange={(e) => setTicket(e.target.value)}
-            className="border border-gray-300 rounded-md p-3 w-full"
+            className="border border-gray-500 rounded-md p-3 w-full bg-transparent"
           />
         </div>
         <button
@@ -42,7 +42,7 @@ export default function FeeCalculator() {
           Calculate
         </button>
       </form>
-      <div className="bg-white p-8 rounded-lg shadow-sm border border-gray-200 flex flex-col justify-center items-center">
+      <div className="bg-[#444654] p-8 rounded-lg shadow-sm border border-[#343541] flex flex-col justify-center items-center text-gray-100">
         {rate !== null ? (
           <>
             <div className="text-lg">

--- a/client/src/pages/MccLookup.jsx
+++ b/client/src/pages/MccLookup.jsx
@@ -52,14 +52,14 @@ export default function MccLookup() {
   };
 
   return (
-    <div className="bg-white p-8 rounded-lg shadow-sm border border-gray-200">
+    <div className="bg-[#444654] p-8 rounded-lg shadow-sm border border-[#343541] text-gray-100">
       <form onSubmit={handleSearch} className="flex space-x-3">
         <input
           type="text"
           placeholder="Search MCC"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
-          className="border border-gray-300 rounded-md p-3 w-full"
+          className="border border-gray-500 rounded-md p-3 w-full bg-transparent"
         />
         <button
           type="submit"
@@ -71,7 +71,7 @@ export default function MccLookup() {
 
       <div className="mt-6 space-y-3">
         {results.map((item) => (
-          <div key={item._id} className="border border-gray-200 rounded-md p-3">
+          <div key={item._id} className="border border-[#343541] rounded-md p-3">
             <p className="font-medium">MCC {item.mcc_code}</p>
             <p className="text-sm">{item.category}</p>
           </div>

--- a/client/src/pages/ProcessorCodes.jsx
+++ b/client/src/pages/ProcessorCodes.jsx
@@ -3,13 +3,13 @@ import { useState } from 'react';
 export default function ProcessorCodes() {
   const [query, setQuery] = useState('');
   return (
-    <div className="bg-white p-8 rounded-lg shadow-sm border border-gray-200 space-y-4">
+    <div className="bg-[#444654] p-8 rounded-lg shadow-sm border border-[#343541] space-y-4 text-gray-100">
       <input
         type="text"
         placeholder="Search processor response"
         value={query}
         onChange={(e) => setQuery(e.target.value)}
-        className="border border-gray-300 rounded-md p-3 w-full"
+        className="border border-gray-500 rounded-md p-3 w-full bg-transparent"
       />
       <div>
         <p className="font-medium">Response 05</p>

--- a/client/src/pages/Reports.jsx
+++ b/client/src/pages/Reports.jsx
@@ -1,6 +1,6 @@
 export default function Reports() {
   return (
-    <div className="bg-white p-6 rounded-lg shadow-sm border border-gray-200">
+    <div className="bg-[#444654] p-6 rounded-lg shadow-sm border border-[#343541] text-gray-100">
       <h2 className="text-lg font-medium mb-2">Reports</h2>
       <p className="text-sm text-gray-500">Your saved reports will appear here.</p>
     </div>

--- a/client/src/pages/Settings.jsx
+++ b/client/src/pages/Settings.jsx
@@ -1,6 +1,6 @@
 export default function Settings() {
   return (
-    <div className="bg-white p-8 rounded-lg shadow-sm border border-gray-200">
+    <div className="bg-[#444654] p-8 rounded-lg shadow-sm border border-[#343541] text-gray-100">
       <h2 className="text-lg font-medium mb-2">Settings</h2>
       <p className="text-sm text-gray-500">User preferences will appear here.</p>
     </div>

--- a/client/src/pages/StatementUpload.jsx
+++ b/client/src/pages/StatementUpload.jsx
@@ -16,14 +16,14 @@ export default function StatementUpload() {
   return (
     <div className="space-y-6">
       <div
-        className="border-2 border-dashed border-gray-300 rounded-lg p-12 text-center bg-white shadow-sm"
+        className="border-2 border-dashed border-gray-500 rounded-lg p-12 text-center bg-[#444654] shadow-sm text-gray-100"
         onDragOver={(e) => e.preventDefault()}
         onDrop={handleDrop}
       >
         {loading ? 'Extracting data…' : 'Drag & drop statement PDF'}
       </div>
       {results && (
-        <div className="bg-white p-8 rounded-lg shadow-sm border border-gray-200">
+        <div className="bg-[#444654] p-8 rounded-lg shadow-sm border border-[#343541] text-gray-100">
           <div className="flex justify-between">
             <h3 className="font-medium">Parsed Results</h3>
             <div>


### PR DESCRIPTION
## Summary
- overhaul layout to dark theme
- remove sidebar icons and shrink layout widths
- simplify topbar and restyle pages

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686dc11d9628832e8b8e780e495ca8eb