### PR TITLE
Ensure main content offset from navbar and topbar

### DIFF
--- a/client/styles.css
+++ b/client/styles.css
@@ -78,7 +78,9 @@ body {
 }
 
 .main-content {
-  padding: 80px 16px 16px 256px;
+  margin-left: 240px;
+  margin-top: 48px;
+  padding: 16px;
 }
 
 .card {
@@ -117,6 +119,8 @@ body {
   }
 
   .main-content {
-    padding-left: 16px;
+    margin-left: 0;
+    margin-top: 48px;
+    padding: 16px;
   }
 }


### PR DESCRIPTION
## Summary
- adjust main content spacing so it's placed below the top bar and to the right of the sidebar
- update responsive rules to use the new spacing approach

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686dc8f650dc832e84dcd91bbf47c218