### PR TITLE
Fix layout so sidebar no longer overlaps content

### DIFF
--- a/client/src/components/Layout.jsx
+++ b/client/src/components/Layout.jsx
@@ -3,10 +3,12 @@ import Topbar from './Topbar';
 
 export default function Layout({ children }) {
   return (
-    <div>
+    <div className="app-layout">
       <Sidebar />
-      <Topbar />
-      <main className="main-content">{children}</main>
+      <div className="content-area">
+        <Topbar />
+        <main className="main-content">{children}</main>
+      </div>
     </div>
   );
 }

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import './index.css';
+import '../styles.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>

--- a/client/styles.css
+++ b/client/styles.css
@@ -8,19 +8,28 @@ body {
   color: #333;
 }
 
+/* Layout containers */
+.app-layout {
+  display: flex;
+  min-height: 100vh;
+}
+
+.content-area {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
 /* Layout */
 .sidebar {
-  position: fixed;
-  top: 0;
-  left: 0;
-  bottom: 0;
   width: 240px;
   background: #ffffff;
   border-right: 1px solid #e5e7eb;
   padding: 16px;
   display: flex;
   flex-direction: column;
-  z-index: 100;
+  flex-shrink: 0;
 }
 
 .sidebar-nav {
@@ -63,10 +72,8 @@ body {
 }
 
 .topbar {
-  position: fixed;
+  position: sticky;
   top: 0;
-  left: 240px;
-  right: 0;
   height: 48px;
   background: #ffffff;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
@@ -74,13 +81,13 @@ body {
   align-items: center;
   justify-content: space-between;
   padding: 0 16px;
-  z-index: 90;
 }
 
 .main-content {
-  margin-left: 240px;
-  margin-top: 48px;
+  flex: 1;
   padding: 16px;
+  margin-top: 48px;
+  overflow-y: auto;
 }
 
 .card {
@@ -106,20 +113,17 @@ body {
 
 @media (max-width: 768px) {
   .sidebar {
+    position: absolute;
     transform: translateX(-100%);
     transition: transform 0.2s ease;
+    z-index: 100;
   }
 
   .sidebar.open {
     transform: translateX(0);
   }
 
-  .topbar {
-    left: 0;
-  }
-
   .main-content {
-    margin-left: 0;
     margin-top: 48px;
     padding: 16px;
   }


### PR DESCRIPTION
## Summary
- import site CSS in main entry
- refactor layout with new wrapper divs
- rewrite styles for sidebar/topbar/main-content

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686dcb748e60832e9fc03ba20b54e38f