### PR TITLE
Fix MCC lookup search

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -9,7 +9,8 @@ app.use(cors());
 app.use(express.json());
 
 const PORT = process.env.PORT || 5000;
-const MONGO_URI = process.env.MONGO_URI || 'mongodb://localhost:27017/paycodesdb';
+// Default to the local `mcc_codes` database if no URI is provided
+const MONGO_URI = process.env.MONGO_URI || 'mongodb://localhost:27017/mcc_codes';
 
 mongoose.set('strictQuery', false);
 mongoose.connect(MONGO_URI)
@@ -29,8 +30,8 @@ app.get('/api/mcc', async (req, res) => {
     const regex = new RegExp(q, 'i');
     const filter = {
       $or: [
-        // Match MCC codes that start with the query
-        { mcc_code: { $regex: `^${q}` } },
+        // Match MCC codes that contain the query
+        { mcc_code: regex },
         // Or categories that contain the query, case-insensitive
         { category: regex }
       ]


### PR DESCRIPTION
## Summary
- search MCC codes using substring match
- default local mongo URI to `mcc_codes`

## Testing
- `npm install` in both server and client
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686dcf4439d8832e99e5993843938d5d