### PR TITLE
Fix dev server instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,17 @@ cd server && npm install
 cd ../client && npm install
 ```
 
+2. Start the Express server (`npm run dev` inside `server/`):
+
 ```bash
+cd server
 npm run dev
 ```
 
-3. In another terminal, start the React development server:
+3. In another terminal, run the React development server (`npm run dev` inside `client/`):
 
 ```bash
+cd client
 npm run dev
 ```
 


### PR DESCRIPTION
## Summary
- fix sequential numbering in README getting started section
- add commands for starting Express and React dev servers

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e71c41d24832ebbe8f461ec18256e