### PR TITLE
Add validation for MONGO_URI

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -11,6 +11,15 @@ app.use(express.json());
 const PORT = process.env.PORT || 5000;
 const MONGO_URI = process.env.MONGO_URI;
 
+// Validate the MongoDB connection string before attempting to connect
+if (
+  !MONGO_URI ||
+  !/^mongodb(?:\+srv)?:\/\//.test(MONGO_URI.trim())
+) {
+  console.error('Error: MONGO_URI environment variable is missing or malformed.');
+  process.exit(1);
+}
+
 mongoose.set('strictQuery', false);
 mongoose.connect(MONGO_URI)
   .then(() => console.log('MongoDB connected'))


### PR DESCRIPTION
## Summary
- exit the API early if `MONGO_URI` is missing or malformed

## Testing
- `npm test --silent` *(fails: missing script)*
- `npm run lint --silent` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686e71c6bf38832eaefa64847953010b