### PR TITLE
Fix MongoDB connection URI

### DIFF
--- a/server/.env
+++ b/server/.env
@@ -1,6 +1,8 @@
 PORT=5000
 
-MONGO_URI=mongodb+srv://paycodesadmin:ItREyl5gSeIOZ6xP@paycodesdb.lsfhh2t.mongodb.net/?retryWrites=true&w=majority&appName=paycodesdb
+# Specify the target database (mcc_codes) so Mongoose queries the
+# correct DB instead of the default "test" database
+MONGO_URI=mongodb+srv://paycodesadmin:ItREyl5gSeIOZ6xP@paycodesdb.lsfhh2t.mongodb.net/mcc_codes?retryWrites=true&w=majority&appName=paycodesdb
 
 # <-- ADD THIS LINE for your React app to know where the API lives
 VITE_API_URL=http://localhost:5000


### PR DESCRIPTION
## Summary
- point MONGO_URI at `mcc_codes` database so queries go to the right DB

## Testing
- `npm test` *(fails: Missing script)*
- `npm run dev` *(fails: ENOTFOUND for MongoDB cluster)*

------
https://chatgpt.com/codex/tasks/task_e_68783a078954832eb70721ba527ee216