### PR TITLE
Fix numeric MCC code lookups

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -45,6 +45,11 @@ app.get('/api/mcc', async (req, res) => {
       ]
     };
 
+    // If the search looks like a number, also check for an exact numeric match
+    if (/^\d+$/.test(q)) {
+      filter.$or.push({ mcc_code: Number(q) });
+    }
+
     const results = await Mcc.find(filter).limit(20);
     res.json(results);
   } catch (err) {

--- a/server/models/Mcc.js
+++ b/server/models/Mcc.js
@@ -1,7 +1,8 @@
 const mongoose = require('mongoose');
 
 const MccSchema = new mongoose.Schema({
-  mcc_code: String,
+  // Some records may store the code as a number, others as a string
+  mcc_code: mongoose.Schema.Types.Mixed,
   category: String
 });
 


### PR DESCRIPTION
## Summary
- broaden `Mcc` schema to allow numeric codes
- extend `/api/mcc` search endpoint to match numeric MCC codes exactly

## Testing
- `node index.js` *(fails: ENOTFOUND paycodesdb.lsfhh2t.mongodb.net)*

------
https://chatgpt.com/codex/tasks/task_e_6878fdd7656c832e9bd2a797a82d9d70